### PR TITLE
Really fix PIP installation

### DIFF
--- a/_uniout.py
+++ b/_uniout.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = '0.3.3'
-
 import re
 
 def literalize_string(content, is_unicode=False):

--- a/_uniout.py
+++ b/_uniout.py
@@ -55,9 +55,10 @@ def unescape_string_literal(literal, encoding):
         content = literal[1:-1].decode('string-escape')
 
         # keep it escaped if the encoding doesn't work on it
+        # TypeError occurs if encoding is None
         try:
             content.decode(encoding)
-        except UnicodeDecodeError:
+        except (UnicodeDecodeError, TypeError):
             return literal
 
     return literalize_string(content)

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@
 
 from setuptools import setup
 
-import _uniout
+import uniout
 
 setup(
 
     name = 'uniout',
-    version = _uniout.__version__,
+    version = uniout.__version__,
     description = 'Never see escaped bytes in output.',
     long_description = open('README.rst').read(),
 

--- a/uniout.py
+++ b/uniout.py
@@ -2,7 +2,9 @@
 # -*- coding: utf-8 -*-
 
 import sys
-from _uniout import __version__, make_unistream, runs_in_ipython
+from _uniout import make_unistream, runs_in_ipython
+
+__version__ = '0.3.3'
 
 if runs_in_ipython():
     from IPython.utils import io


### PR DESCRIPTION
A redirected stream may not have encoding information, causing `unescape_string_literal` to fail with a `TypeError` (because `encoding` is `None`).

I also put the `__version__` variable back to `uniout`. Hope it makes sense.
